### PR TITLE
set proper build env vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR $GOPATH/src/github.com/caesium-dev/caesium
 COPY . .
 
 RUN go get -d -v
-RUN go build -o /go/bin/caesium
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /go/bin/caesium
 
 # Package for lightweight deployment
 FROM scratch


### PR DESCRIPTION
The container I built was garbage using WSL - this ensures it won't be.